### PR TITLE
docs(license): add CC BY 4.0 content licence (#767)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -26,3 +26,4 @@
 ^NIX_SHELL_WORKAROUND\.md$
 ^QUICK_START\.md$
 ^scripts$
+^LICENSE\.content\.md$

--- a/LICENSE.content.md
+++ b/LICENSE.content.md
@@ -1,0 +1,16 @@
+# Content Licence
+
+The **documentation and other content** in this repository — including prose,
+README text, vignettes, the rendered site, figures, diagrams, and datasets — is
+licensed under the
+[Creative Commons Attribution 4.0 International Licence (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).
+
+You are free to share and adapt this content for any purpose, including
+commercially, provided you give appropriate credit.
+
+The **source code** in this repository (everything that executes) is licensed
+separately under the repository's own software licence (see `LICENSE` /
+`DESCRIPTION` where present). Creative Commons licences are not used for source
+code.
+
+Policy: [JohnGavin/llm#767](https://github.com/JohnGavin/llm/issues/767).


### PR DESCRIPTION
Adds `LICENSE.content.md` licensing documentation/content under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/); source code stays under this repo's own licence. Part of the cross-project licensing rollout — policy [JohnGavin/llm#767](https://github.com/JohnGavin/llm/issues/767). Not merged — for review.